### PR TITLE
[Feature] #3 글자 가리기 - 도형 페이지 기본 UI 및 기능 구현

### DIFF
--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -11,6 +11,7 @@
     "classnames": "^2.5.1",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
+    "react-colorful": "^5.6.1",
     "react-dom": "^18.3.1",
     "react-feather": "^2.0.10",
     "react-router-dom": "^6.28.0",

--- a/packages/service/src/components/BottomSheet.tsx
+++ b/packages/service/src/components/BottomSheet.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren, useRef } from "react";
 import { useOnClickOutside } from "../utils/useOnClickOutside";
+import Header from "./Header";
 
 interface BottomSheetProps extends PropsWithChildren {
   title: string;
@@ -17,12 +18,20 @@ const BottomSheet = ({ title, children, onClose }: BottomSheetProps) => {
 
       <div
         ref={bottomSheetRef}
-        className="w-full flex flex-col absolute bottom-0 bg-white rounded-t-md"
+        className="w-full flex flex-col absolute bottom-0 bg-white rounded-t-xl"
       >
-        <div id="bottom-sheet-header" className="">
-          <span>{title}</span>
-        </div>
-        <div id="bottom-sheet-content" className="p-4">
+        <Header
+          title={title}
+          leftBarButtonItems={[
+            {
+              label: "닫기",
+              renderIcon: (options) => <span {...options}>닫기</span>,
+              onClick: onClose,
+            },
+          ]}
+        />
+
+        <div id="bottom-sheet-content" className="p-4 min-h-60">
           {children}
         </div>
       </div>

--- a/packages/service/src/components/Button.tsx
+++ b/packages/service/src/components/Button.tsx
@@ -1,0 +1,32 @@
+import cn from "classnames";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "filled" | "light" | "outlined";
+}
+
+const Button = ({
+  variant = "filled",
+  children,
+  className,
+  ...props
+}: ButtonProps) => {
+  return (
+    <button
+      className={cn(
+        "px-2 min-h-10 rounded-md flex items-center justify-center",
+        variant === "filled" &&
+          "bg-slate-900 text-white hover:bg-slate-800 disabled:bg-slate-400",
+        variant === "light" &&
+          "bg-slate-200 text-slate-800 disabled:bg-slate-100 disabled:text-slate-400 hover:bg-slate-300",
+        variant === "outlined" &&
+          "border border-slate-400 text-slate-600 disabled:bg-slate-100 disabled:border-slate-300 disabled:text-slate-400 hover:border-slate-500 hover:text-slate-800",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/packages/service/src/components/DebouncedColorPicker.tsx
+++ b/packages/service/src/components/DebouncedColorPicker.tsx
@@ -1,0 +1,23 @@
+import debounce from "lodash/debounce";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { HexColorPicker } from "react-colorful";
+
+interface DebouncedColorPicker {
+  color: string;
+  onChange: (newColor: string) => void;
+}
+
+const DebouncedColorPicker = ({ color, onChange }: DebouncedColorPicker) => {
+  const [value, setValue] = useState(color);
+
+  const debouncedChange = useMemo(() => debounce(onChange, 200), [onChange]);
+
+  useEffect(() => {
+    debouncedChange(value);
+    return () => debouncedChange.cancel();
+  }, [value, debouncedChange]);
+
+  return <HexColorPicker color={value} onChange={setValue} />;
+};
+
+export default DebouncedColorPicker;

--- a/packages/service/src/components/Editor/EditorColorBottomSheet.tsx
+++ b/packages/service/src/components/Editor/EditorColorBottomSheet.tsx
@@ -1,0 +1,34 @@
+import { HexColorPicker } from "react-colorful";
+import BottomSheet from "../BottomSheet";
+import { useDrawingController } from "editor/controllers";
+import { MapPin } from "react-feather";
+import DebouncedColorPicker from "../DebouncedColorPicker";
+
+interface EditorColorBottomSheet {
+  onClose: () => void;
+}
+
+const EditorColorBottomSheet = ({ onClose }: EditorColorBottomSheet) => {
+  const { color, changeColor } = useDrawingController();
+
+  return (
+    <BottomSheet title="색상 선택" onClose={onClose}>
+      <div className="flex gap-4 mb-4">
+        <div className="w-full border rounded flex p-3 gap-3 items-center">
+          <div
+            className="w-8 h-8 flex-shrink-0"
+            style={{ background: color }}
+          />
+          <input className="w-full" value={color} />
+        </div>
+        <button className="w-14 h-14 flex-shrink-0 flex items-center justify-center rounded-full border border-slate-300">
+          <MapPin className="text-slate-600" />
+        </button>
+      </div>
+
+      <DebouncedColorPicker color={color} onChange={changeColor} />
+    </BottomSheet>
+  );
+};
+
+export default EditorColorBottomSheet;

--- a/packages/service/src/components/Editor/EditorHeader.tsx
+++ b/packages/service/src/components/Editor/EditorHeader.tsx
@@ -48,6 +48,7 @@ const EditorHeader = ({ title, stepIndex }: EditorHeaderProps) => {
         title={title}
         leftBarButtonItems={[
           {
+            label: "취소",
             renderIcon: (options) => <span {...options}>취소</span>,
             onClick: () => console.log("취소"),
           },

--- a/packages/service/src/components/Editor/EditorShapeBottomSheet.tsx
+++ b/packages/service/src/components/Editor/EditorShapeBottomSheet.tsx
@@ -1,0 +1,36 @@
+import { useDrawingController, useShapeController } from "editor/controllers";
+import BottomSheet from "../BottomSheet";
+
+interface EditorShapeBottomSheetProps {
+  onClose: () => void;
+}
+
+const EditorShapeBottomSheet = ({ onClose }: EditorShapeBottomSheetProps) => {
+  const { addShape } = useShapeController();
+  const { color } = useDrawingController();
+
+  const addRectangle = () => {
+    addShape("RECTANGLE", color);
+    onClose();
+  };
+
+  const addEllipse = () => {
+    addShape("ELLIPSE", color);
+    onClose();
+  };
+
+  return (
+    <BottomSheet title="도형 추가" onClose={onClose}>
+      <div className="flex gap-7 px-1 py-3">
+        <button onClick={addRectangle}>
+          <div className="w-20 h-20 bg-slate-400" />
+        </button>
+        <button onClick={addEllipse}>
+          <div className="w-20 h-20 bg-slate-400 rounded-full" />
+        </button>
+      </div>
+    </BottomSheet>
+  );
+};
+
+export default EditorShapeBottomSheet;

--- a/packages/service/src/components/Header.tsx
+++ b/packages/service/src/components/Header.tsx
@@ -1,4 +1,5 @@
 interface BarButtonItem {
+  label: string;
   renderIcon: (options: { className: string }) => JSX.Element;
   onClick: () => void;
 }
@@ -19,7 +20,7 @@ const Header = ({
       <div>
         {leftBarButtonItems &&
           leftBarButtonItems.map((item) => (
-            <button>
+            <button key={`left-bar-button-${item.label}`}>
               {item.renderIcon({
                 className: "text-base text-slate-500 font-regular",
               })}
@@ -33,7 +34,7 @@ const Header = ({
 
       {rightBarButtonItems &&
         rightBarButtonItems.map((item) => (
-          <button>
+          <button key={`right-bar-button-${item.label}`}>
             {item.renderIcon({
               className: "text-base text-slate-500 font-regular",
             })}

--- a/packages/service/src/index.css
+++ b/packages/service/src/index.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+#bottom-sheet-content .react-colorful {
+  width: 100%;
+}
+
+input {
+  @apply focus-visible:outline-none;
+}

--- a/packages/service/src/pages/EditorPage/EditorDrawingPage.tsx
+++ b/packages/service/src/pages/EditorPage/EditorDrawingPage.tsx
@@ -5,6 +5,10 @@ import { useState } from "react";
 import BottomSheet from "../../components/BottomSheet";
 import { useDrawingController, useShapeController } from "editor/controllers";
 import { throttle } from "lodash";
+import EditorShapeBottomSheet from "../../components/Editor/EditorShapeBottomSheet";
+import EditorColorBottomSheet from "../../components/Editor/EditorColorBottomSheet";
+import Button from "../../components/Button";
+import { PlusCircle } from "react-feather";
 
 const EditorDrawingPage = () => {
   const navigate = useNavigate();
@@ -25,73 +29,65 @@ const EditorDrawingPage = () => {
     setIsShapeSheetOpen(false);
   };
 
-  const addShapeHandler = (type: "RECTANGLE" | "ELLIPSE") => () => {
-    addShape(type, color);
-  };
-
   return (
     <>
       <EditorHeader title="글자 가리기" stepIndex={2} />
 
       <div className="bottom absolute bottom-0 left-0 w-full flex flex-col">
-        <div className="pb-6 flex gap-2 justify-center">
-          <button
-            id="color-control"
-            className="p-2 border"
+        <div className="pb-4 flex gap-2 justify-center">
+          <Button
+            name="color-control"
+            className="w-20 h-20 flex-col gap-1"
+            variant="outlined"
             onClick={() => setIsColorSheetOpen(true)}
           >
             <div
-              className="w-4 h-4 rounded-full"
+              className="w-10 h-10 rounded-lg"
               style={{ backgroundColor: color }}
             />
-            <span>색상</span>
-          </button>
+            <span className="text-xs text-slate-500">색상 선택</span>
+          </Button>
 
-          <button
-            id="brush-control"
-            className="p-2 border flex flex-col items-center"
+          <Button
+            name="brush-control"
+            className="w-20 h-20 flex-col gap-1"
+            variant="outlined"
             onClick={() => setIsBrushSheetOpen(true)}
           >
-            <div
-              className="rounded-full w-1 h-1 bg-emerald-600"
-              style={{
-                width: `${width}px`,
-                height: `${width}px`,
-              }}
-            />
-            <span>{width}px</span>
-            <span>브러쉬</span>
-          </button>
+            <div className="w-5 h-5 flex justify-center items-center">
+              <div
+                className="rounded-full w-1 h-1"
+                style={{
+                  width: `${width + 1}px`,
+                  height: `${width + 1}px`,
+                  backgroundColor: color,
+                }}
+              />
+            </div>
+            <span className="text-xs text-slate-400">{width} px</span>
+            <span className="text-xs text-slate-500">그리기</span>
+          </Button>
 
-          <button
-            id="shape-control"
-            className="p-2 border"
+          <Button
+            name="shape-control"
+            className="w-20 h-20 flex-col gap-1"
+            variant="outlined"
             onClick={() => setIsShapeSheetOpen(true)}
           >
-            도형 추가
-          </button>
+            <PlusCircle className="w-8 h-8 p-1" style={{ color }} />
+            <span className="text-xs text-slate-500">도형 추가</span>
+          </Button>
         </div>
         <div className="px-4 py-3">
           <CTAButton
             label="다음"
+            isFullWidth
             onClick={() => navigate("/editor/text-input")}
           />
         </div>
       </div>
 
-      {isColorSheetOpen && (
-        <BottomSheet title="색상 선택" onClose={closeColorSheet}>
-          <button onClick={() => changeColor("#dc2626")}>
-            <div className="w-4 h-4 bg-red-600 rounded-full" />
-            green
-          </button>
-
-          <button onClick={() => changeColor("#059669")}>
-            <div className="w-4 h-4 bg-emerald-600 rounded-full" />
-            green
-          </button>
-        </BottomSheet>
-      )}
+      {isColorSheetOpen && <EditorColorBottomSheet onClose={closeColorSheet} />}
 
       {isBrushSheetOpen && (
         <BottomSheet title="브러쉬 선택" onClose={closeBrushSheet}>
@@ -107,12 +103,7 @@ const EditorDrawingPage = () => {
         </BottomSheet>
       )}
 
-      {isShapeSheetOpen && (
-        <BottomSheet title="도형 추가" onClose={closeShapeSheet}>
-          <button onClick={addShapeHandler("RECTANGLE")}>네모 추가</button>
-          <button onClick={addShapeHandler("ELLIPSE")}>동그라미 추가</button>
-        </BottomSheet>
-      )}
+      {isShapeSheetOpen && <EditorShapeBottomSheet onClose={closeShapeSheet} />}
     </>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
+      react-colorful:
+        specifier: ^5.6.1
+        version: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -2526,6 +2529,12 @@ packages:
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
+
+  react-colorful@5.6.1:
+    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -5657,6 +5666,11 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+
+  react-colorful@5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:


### PR DESCRIPTION
# Related Issue
close #3 

# 작업 내용
- 그리기 페이지 기본 UI 작업
- 바텀시트 컴포넌트(공통) 수정, 버튼 컴포넌트 (공통) 추가
- 그리기 페이지 바텀시트 분리, 세부 구현
- color picker 추가 (react-colorful 라이브러리 사용)

# Screenshot

![localhost_3300_editor_drawing](https://github.com/user-attachments/assets/2154af7a-b821-4ee7-9d24-593d49ce85f8)

